### PR TITLE
Return TokenResponse from auth endpoint

### DIFF
--- a/src/auth/claims.rs
+++ b/src/auth/claims.rs
@@ -24,6 +24,10 @@ impl Token {
     pub fn user(&self) -> &str {
         &self.0.payload.usr
     }
+
+    pub fn timestamp(&self) -> i64 {
+        self.0.payload.exp.timestamp()
+    }
 }
 
 impl FromStr for Token {

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -3,13 +3,33 @@ pub mod vehicle;
 
 use api::*;
 use auth;
-use model::AuthRequest;
+use model::{AuthRequest, TokenResponse};
+use rocket_contrib::Json;
 
 #[post("/", data = "<request>")]
-pub fn authorize(request: AuthRequest) -> Result<String> {
-    match auth::authorize(&request.user, &request.password).map(|token| token.inner().encode()) {
+pub fn authorize(request: AuthRequest) -> Result<Json<TokenResponse>> {
+    match auth::authorize(&request.user, &request.password) {
         Err(_e) => Err(Error::unauthorized()),
-        Ok(Err(_e)) => Err(Error::new(ErrorKind::InternalServerError, "Unencodable token.")),
-        Ok(Ok(token)) => Ok(token),
+        Ok(token) => {
+            let response = TokenResponse::from_token(token)
+                .map_err(|_| Error::new(ErrorKind::InternalServerError, "Unencodable token"))?;
+
+            Ok(Json(response))
+        }
+    }
+}
+
+// This is used for test scripts, since dealing with a bare token is sooooooo much easier than
+// the alternative. What? You thought I was about to learn how to awk or some shit? Maybe later.
+#[post("/bare", data = "<request>")]
+pub fn authorize_bare(request: AuthRequest) -> Result<String> {
+    match auth::authorize(&request.user, &request.password) {
+        Err(_e) => Err(Error::unauthorized()),
+        Ok(token) => {
+            let response = token.inner().encode()
+                .map_err(|_| Error::new(ErrorKind::InternalServerError, "Unencodable token"))?;
+
+            Ok(response)
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ fn main() {
     rocket::ignite()
         .mount("/auth", routes![
             handler::authorize,
+            handler::authorize_bare,
         ])
         .mount("/api/vehicles", routes![
             handler::vehicle::get,

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,9 +1,11 @@
 mod auth_request;
 mod context;
 mod fillup;
+mod token_response;
 mod vehicle;
 
 pub use model::auth_request::AuthRequest;
 pub use model::context::UserContext;
 pub use model::fillup::*;
+pub use model::token_response::*;
 pub use model::vehicle::*;

--- a/src/model/token_response.rs
+++ b/src/model/token_response.rs
@@ -1,0 +1,15 @@
+use auth::Token;
+use rwt::RwtError;
+
+#[derive(Serialize)]
+pub struct TokenResponse {
+    expiration: i64,
+    token: String,
+}
+
+impl TokenResponse {
+    pub fn from_token(token: Token) -> Result<Self, RwtError> {
+        let expiration = token.timestamp();
+        token.inner().encode().map(|token| TokenResponse { token, expiration })
+    }
+}

--- a/test/add_vehicle
+++ b/test/add_vehicle
@@ -1,3 +1,3 @@
 #!/bin/zsh
-auth_header='Authorization: Bearer '`curl --data @authrequest.json localhost:1337/auth`
+auth_header='Authorization: Bearer '`curl --data @authrequest.json localhost:1337/auth/bare`
 curl -H $auth_header -H "Content-Type: application/json" -d @new_vehicle.json 'localhost:1337/api/vehicles'

--- a/test/authtest
+++ b/test/authtest
@@ -1,5 +1,5 @@
 #!/bin/zsh
-header='Authorization: Bearer '`curl --data @authrequest.json localhost:1337/auth`
+header='Authorization: Bearer '`curl --data @authrequest.json localhost:1337/auth/bare`
 curl -H $header 'localhost:1337/api/vehicles/y0jZaJdL'
 curl -H $header 'localhost:1337/api/vehicles'
 curl -H $header 'localhost:1337/api/vehicles?page=0'


### PR DESCRIPTION
This patch causes the primary auth endpoint to return a `TokenResponse` object that stores not only the token itself but an expiration date for the token. We can then store this along with the token so we know when to go get a new one.

We've also added a new bare token auth endpoint that supports the test scripts we wrote up to this point. Those scripts have been updated to hit the new endpoint.